### PR TITLE
feat: Add pagination support to Messages table view

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,3 +77,5 @@ group :test do
 end
 
 gem "tailwindcss-rails", "~> 2.0"
+
+gem "will_paginate", "~> 3.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -243,6 +243,7 @@ GEM
       sorbet
       sorbet-runtime
       zeitwerk (~> 2.6.0)
+    will_paginate (3.3.1)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.6.0)
@@ -272,6 +273,7 @@ DEPENDENCIES
   web-console
   webdrivers
   whatsapp_sdk
+  will_paginate (~> 3.3)
 
 BUNDLED WITH
    2.3.9

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,5 +1,20 @@
 @tailwind base;
 @tailwind components;
+
+.pagination {
+  @apply flex justify-center;
+  @apply my-2 py-2;
+}
+
+.pagination * {
+  @apply px-2 py-2 mx-2;
+  @apply text-gray-700 no-underline bg-white rounded-lg;
+}
+
+.pagination a:hover {
+  @apply font-semibold text-gray-200 bg-gray-700;
+}
+
 @tailwind utilities;
 
 .main {
@@ -54,4 +69,3 @@ h1, li, p, span { @apply text-white; }
     @apply text-2xl text-white font-bold text-gray-900 dark:text-gray-300;
   }
 }
-

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -18,7 +18,7 @@
 @tailwind utilities;
 
 .main {
-  background-color: #0f172a;
+  @apply bg-white dark:bg-slate-900;
 }
 
 h1, li, p, span { @apply text-white; }

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -2,7 +2,7 @@ class MessagesController < ApplicationController
   before_action :set_message, only: %i[ show edit update destroy ]
 
   def index
-    @messages = Message.last(25).reverse
+    @messages = Message.paginate(page: params[:page], per_page: 10).order(created_at: :desc)
   end
 
   def show

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -20,7 +20,10 @@
             <td><p><%= link_to "Details", message, class:"btn-secondary" %></p></td>
           </tr>
         <% end %>
-        <%= will_paginate @messages %>
+
+        <div class='mx-auto text-center my-4'>
+          <%= will_paginate @messages %>
+        </div>
       </tbody>
       </table>
     </div>

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -20,6 +20,7 @@
             <td><p><%= link_to "Details", message, class:"btn-secondary" %></p></td>
           </tr>
         <% end %>
+        <%= will_paginate @messages %>
       </tbody>
       </table>
     </div>

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -20,12 +20,12 @@
             <td><p><%= link_to "Details", message, class:"btn-secondary" %></p></td>
           </tr>
         <% end %>
-
-        <div class='mx-auto text-center my-4'>
-          <%= will_paginate @messages %>
-        </div>
       </tbody>
       </table>
+
+      <div class='mx-auto text-center my-4'>
+        <%= will_paginate @messages %>
+      </div>
     </div>
   </div>
   <div class="py-4">

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,13 +11,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[7.0].define(version: 2022_10_01_194443) do
-  create_table "articles", force: :cascade do |t|
-    t.string "title"
-    t.text "body"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
   create_table "messages", force: :cascade do |t|
     t.string "message"
     t.string "sender_number"


### PR DESCRIPTION
# Description

Issue Link: #1
Add Pagination to the messages table.

- [x] [Messages#index function](https://github.com/ignacio-chiazzo/ruby_on_rails_whatsapp_example/blob/main/app/controllers/messages_controller.rb#L5) needs to accept a page ID and return the items on that page.
- [x] The [view](https://github.com/ignacio-chiazzo/ruby_on_rails_whatsapp_example/blob/d0be04513434f28f85b5d1ec71a70ba7e97eefe7/app/views/messages/index.html.erb#L15) needs to implement pagination.
- [x] Add proper styling and CSS changes


# Screenshots

## Chrome (Light Mode on Mac OS)

OLD:
<img width="1434" alt="Screenshot 2022-10-26 at 1 24 36 PM" src="https://user-images.githubusercontent.com/19902688/197967636-b34037b0-439a-469d-b0f7-622089522857.png">

NOW:
<img width="1440" alt="Screenshot 2022-10-28 at 8 24 49 PM" src="https://user-images.githubusercontent.com/19902688/198661160-5d56a68e-5ed0-4067-928e-b7fc8b3d65db.png">


cc: @ignacio-chiazzo It seems that in the light mode the heading title CSS is not applied correctly, as it takes white text-color, will check and try to find a work around.

PS: Have updated the background color in light mode, by setting separate property for dark mode: https://tailwindcss.com/docs/dark-mode

## Chrome (Dark Mode on Mac OS)

<img width="1440" alt="Screenshot 2022-10-28 at 8 21 38 PM" src="https://user-images.githubusercontent.com/19902688/198660853-84e95d59-6123-4f10-bd60-39904cdd20f2.png">
